### PR TITLE
Take care of arrays in extended attributes (includes a patch from joshtaylor)

### DIFF
--- a/lib/redmine_rubycas.rb
+++ b/lib/redmine_rubycas.rb
@@ -52,7 +52,10 @@ module RedmineRubyCas
     map = extra_attributes_map
     if extra_attributes = session[:"#{setting("extra_attributes_session_key")}"]
       extra_attributes.each_pair do |key, val|
-        attrs[map[key]] = val
+        mapped_key = map[key]
+        if mapped_key && User.attribute_method?(mapped_key)
+          attrs[mapped_key] = val
+        end
       end
     end
     attrs

--- a/lib/redmine_rubycas.rb
+++ b/lib/redmine_rubycas.rb
@@ -54,7 +54,7 @@ module RedmineRubyCas
       extra_attributes.each_pair do |key, val|
         mapped_key = map[key]
         if mapped_key && User.attribute_method?(mapped_key)
-          attrs[mapped_key] = val
+          attrs[mapped_key] = (val.is_a? Array) ? val.first : val
         end
       end
     end


### PR DESCRIPTION
Only use extended attributes which are well known in user model (see comments from joshtaylor) and take care of array values. The cas server may send an array as an extended attribute, especially if ldap is used for authentication.
