### PR TITLE
Fix for redirect loop when "Auto Create Users" is disabled

### DIFF
--- a/lib/account_controller_patch.rb
+++ b/lib/account_controller_patch.rb
@@ -21,8 +21,8 @@ module AccountControllerPatch
                 onthefly_creation_failed(user)
               end
             else
-              flash[:error] = l(:cas_user_not_found, :user => session[:"#{RedmineRubyCas.setting("username_session_key")}"])
-              redirect_to home_url
+              flash.now[:error] = l(:cas_user_not_found, :user => session[:"#{RedmineRubyCas.setting("username_session_key")}"])
+              login_without_cas
             end
           else
             if user.active?


### PR DESCRIPTION
With "Auto Create Users" disabled, not existing user ended up in an infinite redirect loop. This change fixed the problem for me.
