### PR TITLE
Only try to load settings, when db already migrated

### DIFF
--- a/lib/redmine_rubycas.rb
+++ b/lib/redmine_rubycas.rb
@@ -10,8 +10,10 @@ module RedmineRubyCas
   end
 
   def settings
-    if self.plugin
-      Setting.plugin_redmine_rubycas || plugin.settings[:default]
+    if ActiveRecord::Base.connection.table_exists?(:settings) && self.plugin && Setting.plugin_redmine_rubycas
+      Setting.plugin_redmine_rubycas
+    else
+      plugin.settings[:default]
     end
   end
 


### PR DESCRIPTION
I had the problem, that rake db:migrate failed, because redmine_rubycas tried to load the settings in `init.rb` but the database table with the settings did not yet exist:

```
$ rake db:schema:load
rake aborted!
Mysql2::Error: Table 'redmine_development.settings' doesn't exist: SHOW FULL FIELDS FROM `settings`
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:243:in `query'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:243:in `block in execute'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract_adapter.rb:280:in `block in log'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activesupport-3.2.12/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract_adapter.rb:275:in `log'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:243:in `execute'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/connection_adapters/mysql2_adapter.rb:211:in `execute'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:257:in `execute_and_free'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:424:in `columns'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/connection_adapters/schema_cache.rb:12:in `block in initialize'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/model_schema.rb:228:in `yield'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/model_schema.rb:228:in `default'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/model_schema.rb:228:in `columns'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/model_schema.rb:248:in `column_names'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/model_schema.rb:261:in `column_methods_hash'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/dynamic_matchers.rb:74:in `all_attributes_exists?'
/Users/pencil/.rvm/gems/ruby-1.9.3-p194/gems/activerecord-3.2.12/lib/active_record/dynamic_matchers.rb:27:in `method_missing'
/Users/pencil/Projects/redmine/app/models/setting.rb:171:in `find_or_default'
/Users/pencil/Projects/redmine/app/models/setting.rb:108:in `[]'
/Users/pencil/Projects/redmine/app/models/setting.rb:137:in `plugin_redmine_rubycas'
/Users/pencil/Projects/redmine/plugins/redmine_rubycas/lib/redmine_rubycas.rb:14:in `settings'
/Users/pencil/Projects/redmine/plugins/redmine_rubycas/lib/redmine_rubycas.rb:19:in `setting'
/Users/pencil/Projects/redmine/plugins/redmine_rubycas/lib/redmine_rubycas.rb:23:in `enabled?'
/Users/pencil/Projects/redmine/plugins/redmine_rubycas/lib/redmine_rubycas.rb:27:in `configure!'
/Users/pencil/Projects/redmine/plugins/redmine_rubycas/init.rb:37:in `<top (required)>'
...
```

This change fixed it for me.
